### PR TITLE
Reduce test params & update README for package install

### DIFF
--- a/PerformanceTest/TestPerformance.cs
+++ b/PerformanceTest/TestPerformance.cs
@@ -17,7 +17,7 @@ namespace PerformanceTest
     public class TestPerformance
     {
         private string tempFile = string.Empty;
-        [Params(1_000, 100_000, 1_000_000, 10_000_000_000)]
+        [Params(1_000, 100_000, 1_000_000, 100_000_000)]
         public long RowCount { get; set; }
         [GlobalSetup]
         public void Setup()

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ Task<ProcessResult> ProcessAsync<T>(
 
 ## Quick Start
 ```bash
-# (Assuming .NET 10 preview toolchain installed)
-dotnet add package (not published yet) # currently local source only
+dotnet add package ParallelFileProcessor
 ```
 
 ### Minimal Example (count lines containing an error token)


### PR DESCRIPTION
Reduce test params & update README for package install

Reduced the upper limit of `RowCount` in `TestPerformance.cs`
from `10_000_000_000` to `100_000_000` to optimize resource
usage during performance tests.

Updated `README.md` to replace placeholder package installation
instructions with the actual package name `ParallelFileProcessor`,
indicating the package is now available for use.

#### PR Classification
Documentation and performance test parameter adjustment.

#### PR Summary
This pull request updates performance test parameters and improves the Quick Start documentation for better usability.  
- **TestPerformance.cs**: Adjusted `[Params]` attribute values in the `TestPerformance` class to remove an impractically large test case.  
- **README.md**: Updated Quick Start instructions to replace placeholder comments with the published `ParallelFileProcessor` package installation command.  
